### PR TITLE
Create static Nuxt marketing site for AcadNexus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.nuxt
+.output
+.cache
+*.log
+.DS_Store
+.env

--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+}

--- a/components/BlogCard.vue
+++ b/components/BlogCard.vue
@@ -1,0 +1,39 @@
+<template>
+  <article class="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <img :src="image" :alt="`${title} featured image`" class="h-48 w-full object-cover" loading="lazy" />
+    <div class="flex flex-1 flex-col gap-4 p-6">
+      <div class="space-y-2">
+        <p class="text-xs font-medium uppercase tracking-wide text-primary">{{ formattedDate }}</p>
+        <h3 class="text-xl font-semibold text-slate-900">
+          <NuxtLink :to="`/blog/${slug}`" class="hover:text-primary">{{ title }}</NuxtLink>
+        </h3>
+        <p class="text-sm text-slate-600">{{ excerpt }}</p>
+      </div>
+      <div class="mt-auto">
+        <NuxtLink
+          :to="`/blog/${slug}`"
+          class="inline-flex items-center gap-1 text-sm font-semibold text-primary hover:text-primary-dark"
+        >
+          Read More
+          <span aria-hidden="true">→</span>
+        </NuxtLink>
+      </div>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  title: string;
+  excerpt: string;
+  image: string;
+  slug: string;
+  date: string;
+}>();
+
+const formattedDate = computed(() => new Date(props.date).toLocaleDateString(undefined, {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+}));
+</script>

--- a/components/Breadcrumbs.vue
+++ b/components/Breadcrumbs.vue
@@ -1,0 +1,23 @@
+<template>
+  <nav aria-label="Breadcrumb" class="text-sm text-slate-600">
+    <ol class="flex flex-wrap items-center gap-2">
+      <li v-for="(item, index) in path" :key="item.href" class="flex items-center gap-2">
+        <NuxtLink
+          v-if="index !== path.length - 1"
+          :to="item.href"
+          class="text-slate-500 hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        >
+          {{ item.label }}
+        </NuxtLink>
+        <span v-else class="font-semibold text-slate-900" aria-current="page">{{ item.label }}</span>
+        <span v-if="index !== path.length - 1" aria-hidden="true">/</span>
+      </li>
+    </ol>
+  </nav>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  path: { label: string; href: string }[];
+}>();
+</script>

--- a/components/ContactForm.vue
+++ b/components/ContactForm.vue
@@ -1,0 +1,111 @@
+<template>
+  <form @submit.prevent="handleSubmit" novalidate class="space-y-6" aria-labelledby="contact-heading">
+    <div>
+      <label for="name" class="block text-sm font-medium text-slate-700">Name</label>
+      <input
+        id="name"
+        v-model="form.name"
+        type="text"
+        required
+        class="mt-1 w-full rounded-lg border border-slate-300 px-4 py-3 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50"
+        :aria-invalid="!!errors.name"
+        aria-describedby="name-error"
+      />
+      <p v-if="errors.name" id="name-error" class="mt-1 text-xs text-red-600">{{ errors.name }}</p>
+    </div>
+    <div>
+      <label for="email" class="block text-sm font-medium text-slate-700">Email</label>
+      <input
+        id="email"
+        v-model="form.email"
+        type="email"
+        required
+        class="mt-1 w-full rounded-lg border border-slate-300 px-4 py-3 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50"
+        :aria-invalid="!!errors.email"
+        aria-describedby="email-error"
+      />
+      <p v-if="errors.email" id="email-error" class="mt-1 text-xs text-red-600">{{ errors.email }}</p>
+    </div>
+    <div>
+      <label for="message" class="block text-sm font-medium text-slate-700">Message</label>
+      <textarea
+        id="message"
+        v-model="form.message"
+        required
+        rows="5"
+        class="mt-1 w-full rounded-lg border border-slate-300 px-4 py-3 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50"
+        :aria-invalid="!!errors.message"
+        aria-describedby="message-error"
+      ></textarea>
+      <p v-if="errors.message" id="message-error" class="mt-1 text-xs text-red-600">{{ errors.message }}</p>
+    </div>
+    <button
+      type="submit"
+      class="inline-flex w-full items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white transition hover:bg-primary-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary md:w-auto"
+      :disabled="submitting"
+    >
+      <span v-if="submitting" class="flex items-center gap-2">
+        <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+        </svg>
+        Sending...
+      </span>
+      <span v-else>{{ props.buttonLabel }}</span>
+    </button>
+    <p v-if="statusMessage" class="text-sm" :class="statusClass">{{ statusMessage }}</p>
+  </form>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    submitAction?: (payload: { name: string; email: string; message: string }) => Promise<void> | void;
+    buttonLabel?: string;
+  }>(),
+  {
+    buttonLabel: 'Send'
+  }
+);
+
+const form = reactive({
+  name: '',
+  email: '',
+  message: ''
+});
+
+const errors = reactive<{ name?: string; email?: string; message?: string }>({});
+const submitting = ref(false);
+const statusMessage = ref('');
+const statusClass = ref('text-slate-600');
+
+const validate = () => {
+  errors.name = form.name.trim() ? undefined : 'Please enter your name.';
+  errors.email = /.+@.+\..+/.test(form.email) ? undefined : 'Enter a valid email address.';
+  errors.message = form.message.trim().length >= 10 ? undefined : 'Message should be at least 10 characters.';
+  return !errors.name && !errors.email && !errors.message;
+};
+
+const handleSubmit = async () => {
+  statusMessage.value = '';
+  if (!validate()) return;
+  submitting.value = true;
+  try {
+    if (props.submitAction) {
+      await props.submitAction({ ...form });
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 800));
+    }
+    statusMessage.value = 'Thank you! Your message has been sent.';
+    statusClass.value = 'text-green-600';
+    form.name = '';
+    form.email = '';
+    form.message = '';
+  } catch (error) {
+    statusMessage.value = 'Something went wrong. Please try again later.';
+    statusClass.value = 'text-red-600';
+  } finally {
+    submitting.value = false;
+  }
+};
+</script>

--- a/components/CourseCard.vue
+++ b/components/CourseCard.vue
@@ -1,0 +1,36 @@
+<template>
+  <article class="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+    <img :src="image" :alt="`${title} cover image`" class="h-48 w-full object-cover" loading="lazy" />
+    <div class="flex flex-1 flex-col gap-4 p-6">
+      <div class="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-primary">
+        <span>{{ category }}</span>
+        <span>{{ duration }}</span>
+      </div>
+      <div class="space-y-3">
+        <h3 class="text-xl font-semibold text-slate-900">
+          <NuxtLink :to="cta" class="hover:text-primary">{{ title }}</NuxtLink>
+        </h3>
+        <p class="text-sm text-slate-600">{{ description }}</p>
+      </div>
+      <div class="mt-auto">
+        <NuxtLink
+          :to="cta"
+          class="inline-flex items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        >
+          Explore Course
+        </NuxtLink>
+      </div>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  title: string;
+  description: string;
+  image: string;
+  category: string;
+  duration: string;
+  cta: string;
+}>();
+</script>

--- a/components/FAQItem.vue
+++ b/components/FAQItem.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+    <button
+      class="flex w-full items-center justify-between text-left text-base font-semibold text-slate-900"
+      @click="isOpen = !isOpen"
+      :aria-expanded="isOpen"
+    >
+      {{ question }}
+      <span class="ml-4 text-primary">{{ isOpen ? '-' : '+' }}</span>
+    </button>
+    <transition name="collapse">
+      <p v-if="isOpen" class="mt-4 text-sm text-slate-600">
+        {{ answer }}
+      </p>
+    </transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  question: string;
+  answer: string;
+}>();
+
+const isOpen = ref(false);
+</script>
+
+<style scoped>
+.collapse-enter-active,
+.collapse-leave-active {
+  transition: all 0.2s ease;
+}
+.collapse-enter-from,
+.collapse-leave-to {
+  max-height: 0;
+  opacity: 0;
+}
+</style>

--- a/components/FeatureCard.vue
+++ b/components/FeatureCard.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+    <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+      <component :is="icon" class="h-6 w-6" aria-hidden="true" />
+    </div>
+    <div>
+      <h3 class="text-lg font-semibold text-slate-900">{{ title }}</h3>
+      <p class="mt-2 text-sm text-slate-600">{{ description }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  icon: any;
+  title: string;
+  description: string;
+}>();
+</script>

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,0 +1,64 @@
+<template>
+  <footer class="bg-slate-900 text-slate-200" role="contentinfo">
+    <div class="mx-auto flex max-w-7xl flex-col gap-10 px-4 py-12 md:flex-row md:justify-between">
+      <div class="max-w-md space-y-4">
+        <div class="flex items-center gap-2">
+          <img src="/images/logo-light.svg" alt="AcadNexus logo" class="h-9 w-auto" loading="lazy" />
+          <span class="text-xl font-semibold">AcadNexus</span>
+        </div>
+        <p class="text-sm text-slate-300">
+          AcadNexus empowers learners with expertly crafted courses, personalized learning paths, and insights from industry leaders.
+        </p>
+      </div>
+      <div class="grid flex-1 grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3">
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-400">Explore</h3>
+          <ul class="mt-4 space-y-2 text-sm">
+            <li v-for="link in links" :key="link.href">
+              <NuxtLink
+                :to="link.href"
+                class="hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                {{ link.label }}
+              </NuxtLink>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-400">Contact</h3>
+          <ul class="mt-4 space-y-2 text-sm text-slate-300">
+            <li>Email: <a class="hover:text-white" href="mailto:hello@acadnexus.com">hello@acadnexus.com</a></li>
+            <li>Phone: <a class="hover:text-white" href="tel:+1234567890">+1 (234) 567-890</a></li>
+            <li>Address: 123 Innovation Drive, Boston, MA</li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-400">Follow Us</h3>
+          <ul class="mt-4 flex items-center gap-4">
+            <li v-for="icon in social" :key="icon.href">
+              <a
+                :href="icon.href"
+                target="_blank"
+                rel="noopener"
+                class="flex h-10 w-10 items-center justify-center rounded-full border border-slate-700 text-slate-300 transition hover:border-white hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                <span class="sr-only">{{ icon.label }}</span>
+                <component :is="icon.component" class="h-5 w-5" aria-hidden="true" />
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="border-t border-slate-800 bg-slate-950 py-4">
+      <p class="text-center text-xs text-slate-500">© {{ new Date().getFullYear() }} AcadNexus. All rights reserved.</p>
+    </div>
+  </footer>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  links: { label: string; href: string }[];
+  social: { label: string; href: string; component: any }[];
+}>();
+</script>

--- a/components/HeroSection.vue
+++ b/components/HeroSection.vue
@@ -1,0 +1,49 @@
+<template>
+  <section class="relative overflow-hidden bg-slate-900 py-24 text-white">
+    <div class="absolute inset-0 bg-gradient-to-br from-primary via-primary-dark to-slate-900 opacity-80"></div>
+    <div class="relative mx-auto flex max-w-7xl flex-col items-center gap-10 px-4 text-center md:flex-row md:text-left">
+      <div class="space-y-6 md:w-1/2">
+        <p class="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-sm font-medium uppercase tracking-wide">
+          Empowering Lifelong Learners
+        </p>
+        <h1 class="text-4xl font-bold sm:text-5xl md:text-6xl">
+          {{ title }}
+        </h1>
+        <p class="max-w-xl text-lg text-slate-200">
+          {{ subtitle }}
+        </p>
+        <div class="flex flex-col gap-3 sm:flex-row">
+          <NuxtLink
+            :to="ctaLink"
+            class="rounded-full bg-white px-6 py-3 text-base font-semibold text-primary shadow-lg transition hover:-translate-y-1 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            {{ ctaText }}
+          </NuxtLink>
+          <NuxtLink
+            to="/courses"
+            class="rounded-full border border-white/50 px-6 py-3 text-base font-semibold text-white transition hover:border-white hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          >
+            Browse Courses
+          </NuxtLink>
+        </div>
+      </div>
+      <div class="md:w-1/2">
+        <img
+          src="/images/hero-illustration.svg"
+          alt="Learners collaborating online"
+          class="mx-auto w-full max-w-xl"
+          loading="lazy"
+        />
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  title: string;
+  subtitle: string;
+  ctaText: string;
+  ctaLink: string;
+}>();
+</script>

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -1,0 +1,92 @@
+<template>
+  <header class="bg-white/90 backdrop-blur border-b border-slate-200 sticky top-0 z-50" role="banner">
+    <nav class="mx-auto flex max-w-7xl items-center justify-between px-4 py-4" aria-label="Main">
+      <NuxtLink to="/" class="flex items-center gap-2" aria-label="AcadNexus home">
+        <img src="/images/logo.svg" alt="AcadNexus logo" class="h-9 w-auto" loading="lazy" />
+        <span class="text-xl font-bold text-primary">AcadNexus</span>
+      </NuxtLink>
+      <button
+        class="md:hidden inline-flex items-center justify-center rounded-md p-2 text-slate-700 focus:outline-none focus:ring-2 focus:ring-primary"
+        @click="isOpen = !isOpen"
+        :aria-expanded="isOpen"
+        :aria-label="isOpen ? 'Close navigation menu' : 'Open navigation menu'"
+      >
+        <span class="sr-only">Toggle navigation</span>
+        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path v-if="!isOpen" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+      <ul
+        class="hidden md:flex items-center gap-8 text-sm font-medium text-slate-700"
+      >
+        <li v-for="link in links" :key="link.href">
+          <NuxtLink
+            :to="link.href"
+            class="transition hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            {{ link.label }}
+          </NuxtLink>
+        </li>
+        <li>
+          <NuxtLink
+            to="/contact"
+            class="rounded-full bg-primary px-4 py-2 text-white shadow hover:bg-primary-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            Get Started
+          </NuxtLink>
+        </li>
+      </ul>
+    </nav>
+    <transition name="fade">
+      <div v-if="isOpen" class="md:hidden border-t border-slate-200 bg-white" role="dialog" aria-modal="true">
+        <ul class="space-y-1 px-4 py-4 text-base font-medium text-slate-700">
+          <li v-for="link in links" :key="link.href">
+            <NuxtLink
+              :to="link.href"
+              class="block rounded px-3 py-2 hover:bg-primary/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              @click="isOpen = false"
+            >
+              {{ link.label }}
+            </NuxtLink>
+          </li>
+          <li>
+            <NuxtLink
+              to="/contact"
+              class="mt-3 block rounded-full bg-primary px-4 py-2 text-center text-white shadow hover:bg-primary-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              @click="isOpen = false"
+            >
+              Get Started
+            </NuxtLink>
+          </li>
+        </ul>
+      </div>
+    </transition>
+  </header>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  links: { label: string; href: string }[];
+}>();
+
+const isOpen = ref(false);
+
+watch(
+  () => useRoute().path,
+  () => {
+    isOpen.value = false;
+  }
+);
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/components/NotFound.vue
+++ b/components/NotFound.vue
@@ -1,0 +1,34 @@
+<template>
+  <section class="mx-auto flex max-w-3xl flex-col items-center gap-6 px-4 py-24 text-center">
+    <p class="text-sm font-semibold uppercase tracking-wide text-primary">Error 404</p>
+    <h1 class="text-4xl font-bold text-slate-900">{{ message }}</h1>
+    <p class="text-base text-slate-600">
+      The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.
+    </p>
+    <div class="flex flex-col gap-3 sm:flex-row">
+      <NuxtLink
+        to="/"
+        class="rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white transition hover:bg-primary-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      >
+        Back to Home
+      </NuxtLink>
+      <NuxtLink
+        to="/contact"
+        class="rounded-full border border-primary px-6 py-3 text-sm font-semibold text-primary transition hover:bg-primary/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+      >
+        Contact Support
+      </NuxtLink>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    message?: string;
+  }>(),
+  {
+    message: 'Page not found'
+  }
+);
+</script>

--- a/components/StaticContent.vue
+++ b/components/StaticContent.vue
@@ -1,0 +1,5 @@
+<template>
+  <section class="prose prose-slate max-w-none dark:prose-invert">
+    <slot />
+  </section>
+</template>

--- a/components/TestimonialCard.vue
+++ b/components/TestimonialCard.vue
@@ -1,0 +1,20 @@
+<template>
+  <figure class="flex h-full flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+    <blockquote class="text-sm text-slate-600">“{{ message }}”</blockquote>
+    <figcaption class="mt-auto flex items-center gap-3">
+      <img :src="avatar" :alt="`${name} avatar`" class="h-12 w-12 rounded-full object-cover" loading="lazy" />
+      <div>
+        <p class="text-base font-semibold text-slate-900">{{ name }}</p>
+        <slot name="role" />
+      </div>
+    </figcaption>
+  </figure>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  name: string;
+  avatar: string;
+  message: string;
+}>();
+</script>

--- a/data/content.ts
+++ b/data/content.ts
@@ -1,0 +1,143 @@
+export const courses = [
+  {
+    slug: 'ai-basics',
+    title: 'AI Fundamentals',
+    description: 'Understand core AI concepts, machine learning workflows, and ethical considerations for modern practitioners.',
+    category: 'Artificial Intelligence',
+    duration: '6 weeks',
+    level: 'Beginner',
+    image: '/images/courses/ai-course.svg',
+    syllabus: [
+      'Foundations of artificial intelligence and history',
+      'Machine learning algorithms and model evaluation',
+      'Practical labs with Python and open-source tools',
+      'Responsible AI and bias mitigation strategies'
+    ],
+    instructor: {
+      name: 'Dr. Aisha Patel',
+      role: 'Lead AI Strategist',
+      bio: 'Dr. Patel has led AI transformation projects across Fortune 500 companies and mentors emerging data scientists.'
+    }
+  },
+  {
+    slug: 'full-stack-web',
+    title: 'Full-Stack Web Development',
+    description: 'Build responsive web applications from scratch with modern tooling, frameworks, and deployment strategies.',
+    category: 'Web Development',
+    duration: '8 weeks',
+    level: 'Intermediate',
+    image: '/images/courses/web-course.svg',
+    syllabus: [
+      'Modern HTML, CSS, and accessible design patterns',
+      'JavaScript fundamentals and state management',
+      'Backend APIs with Node.js and databases',
+      'Deployment, CI/CD, and performance optimization'
+    ],
+    instructor: {
+      name: 'Miguel Santos',
+      role: 'Senior Software Engineer',
+      bio: 'Miguel has shipped scalable web apps for startups and global enterprises with a focus on inclusive design.'
+    }
+  },
+  {
+    slug: 'data-storytelling',
+    title: 'Data Storytelling & Visualization',
+    description: 'Transform complex datasets into compelling narratives with visualization techniques and human-centered storytelling.',
+    category: 'Data Analytics',
+    duration: '4 weeks',
+    level: 'All Levels',
+    image: '/images/courses/data-course.svg',
+    syllabus: [
+      'Designing with data: clarity, context, and emotion',
+      'Choosing the right chart types and dashboards',
+      'Interactive storytelling with popular BI tools',
+      'Presenting insights to stakeholders effectively'
+    ],
+    instructor: {
+      name: 'Sophia Chen',
+      role: 'Principal Data Analyst',
+      bio: 'Sophia helps organizations democratize data literacy through immersive workshops and coaching.'
+    }
+  }
+];
+
+export const blogPosts = [
+  {
+    slug: 'ai-in-2025',
+    title: 'AI in 2025: Navigating the Next Frontier',
+    excerpt: 'Discover the trends shaping AI adoption, governance, and talent readiness in the coming years.',
+    image: '/images/blog/ai-blog.svg',
+    category: 'Artificial Intelligence',
+    author: 'Dr. Aisha Patel',
+    date: '2025-01-12',
+    content: [
+      'Artificial intelligence continues to evolve at an exponential pace, reshaping industries and redefining roles across the workforce.',
+      'In 2025, organizations will prioritize responsible AI frameworks, ensuring transparency and accountability in automated decisions.',
+      'Upskilling remains critical: multidisciplinary teams that blend technical, ethical, and strategic expertise will lead the way.'
+    ]
+  },
+  {
+    slug: 'designing-learning-experiences',
+    title: 'Designing Learning Experiences That Stick',
+    excerpt: 'Explore how AcadNexus builds immersive learning experiences rooted in neuroscience and community engagement.',
+    image: '/images/blog/learning-experiences.svg',
+    category: 'Learning Science',
+    author: 'Elena Morris',
+    date: '2025-02-18',
+    content: [
+      'Great learning experiences blend storytelling, practice, and timely feedback.',
+      'AcadNexus uses cohort-based learning to build momentum and accountability amongst learners.',
+      'By combining synchronous labs with asynchronous resources, learners can personalize their journey while feeling supported.'
+    ]
+  },
+  {
+    slug: 'future-of-work-skills',
+    title: 'Future of Work Skills Every Professional Needs',
+    excerpt: 'A practical roadmap for mastering human-centric and technical skills to stay resilient in dynamic markets.',
+    image: '/images/blog/future-skills.svg',
+    category: 'Career Development',
+    author: 'Miguel Santos',
+    date: '2025-03-05',
+    content: [
+      'Employers seek adaptive problem solvers who can collaborate across disciplines and leverage data-driven insights.',
+      'Hybrid roles will dominate the future workplace, blending leadership, creativity, and digital fluency.',
+      'Continuous learning platforms like AcadNexus offer curated pathways to build skills while applying them to real-world projects.'
+    ]
+  }
+];
+
+export const testimonials = [
+  {
+    name: 'Jordan Rivers',
+    avatar: '/images/testimonials/jordan.svg',
+    role: 'Product Manager, Horizon Labs',
+    message: 'AcadNexus helped our team build AI literacy fast. The blend of strategy and hands-on labs is unmatched.'
+  },
+  {
+    name: 'Priya Desai',
+    avatar: '/images/testimonials/priya.svg',
+    role: 'Data Analyst, InsightWorks',
+    message: 'The mentorship and community kept me accountable. I landed a promotion within two months of finishing the program.'
+  },
+  {
+    name: 'Alex Morgan',
+    avatar: '/images/testimonials/alex.svg',
+    role: 'Learning & Development Lead, NovaCorp',
+    message: 'Our organization partnered with AcadNexus to upskill 200+ employees. The results were transformative.'
+  }
+];
+
+export const faqs = [
+  {
+    question: 'How are AcadNexus courses structured?',
+    answer: 'Courses combine live workshops, on-demand modules, and real-world projects. Learners receive ongoing feedback from mentors.'
+  },
+  {
+    question: 'Do you offer corporate training packages?',
+    answer: 'Yes. We build custom academies for enterprises with dedicated cohort success managers and tailored metrics.'
+  },
+  {
+    question: 'What support do learners receive?',
+    answer: 'Learners gain access to coaching sessions, community forums, and weekly office hours with instructors.'
+  }
+];

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="min-h-screen bg-slate-50 text-slate-900">
+    <Navbar :links="navigationLinks" />
+    <main class="flex-1">
+      <slot />
+    </main>
+    <Footer :links="footerLinks" :social="socialLinks" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue';
+
+const navigationLinks = [
+  { label: 'About', href: '/about' },
+  { label: 'Courses', href: '/courses' },
+  { label: 'Blog', href: '/blog' },
+  { label: 'FAQ', href: '/faq' },
+  { label: 'Contact', href: '/contact' }
+];
+
+const footerLinks = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about' },
+  { label: 'Courses', href: '/courses' },
+  { label: 'Blog', href: '/blog' },
+  { label: 'FAQ', href: '/faq' },
+  { label: 'Terms', href: '/terms' },
+  { label: 'Privacy', href: '/privacy' }
+];
+
+const socialLinks = [
+  {
+    label: 'LinkedIn',
+    href: 'https://www.linkedin.com/company/acadnexus',
+    component: {
+      render() {
+        return h('svg', { class: 'h-5 w-5', fill: 'currentColor', viewBox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg' }, [
+          h('path', {
+            d: 'M20.452 20.452h-3.555v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.447-2.136 2.943v5.663H9.354V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.368-1.852 3.601 0 4.267 2.37 4.267 5.455v6.288zM5.337 7.433c-1.144 0-2.069-.926-2.069-2.068 0-1.144.925-2.069 2.069-2.069 1.142 0 2.068.925 2.068 2.069 0 1.142-.926 2.068-2.068 2.068zm1.777 13.019H3.559V9h3.555v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z'
+          })
+        ]);
+      }
+    }
+  },
+  {
+    label: 'Twitter',
+    href: 'https://twitter.com/acadnexus',
+    component: {
+      render() {
+        return h('svg', { class: 'h-5 w-5', fill: 'currentColor', viewBox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg' }, [
+          h('path', {
+            d: 'M21.543 7.104c.015.211.015.423.015.636 0 6.507-4.954 14.012-14.012 14.012A13.93 13.93 0 010 19.539a9.86 9.86 0 007.257-2.037 4.93 4.93 0 01-4.597-3.417 4.93 4.93 0 002.22-.085 4.926 4.926 0 01-3.95-4.828v-.062a4.89 4.89 0 002.23.616 4.924 4.924 0 01-1.523-6.573 13.978 13.978 0 0010.15 5.146 5.563 5.563 0 01-.123-1.126 4.926 4.926 0 018.517-3.367 9.72 9.72 0 003.127-1.195 4.92 4.92 0 01-2.165 2.724 9.868 9.868 0 002.828-.77 10.6 10.6 0 01-2.464 2.56z'
+          })
+        ]);
+      }
+    }
+  },
+  {
+    label: 'YouTube',
+    href: 'https://youtube.com/@acadnexus',
+    component: {
+      render() {
+        return h('svg', { class: 'h-5 w-5', fill: 'currentColor', viewBox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg' }, [
+          h('path', {
+            d: 'M23.498 6.186a2.971 2.971 0 00-2.09-2.102C19.44 3.5 12 3.5 12 3.5s-7.44 0-9.408.584a2.971 2.971 0 00-2.09 2.102A31.287 31.287 0 000 12a31.287 31.287 0 00.502 5.814 2.971 2.971 0 002.09 2.102C4.56 20.5 12 20.5 12 20.5s7.44 0 9.408-.584a2.971 2.971 0 002.09-2.102A31.287 31.287 0 0024 12a31.287 31.287 0 00-.502-5.814zM9.75 15.568V8.432L15.818 12 9.75 15.568z'
+          })
+        ]);
+      }
+    }
+  }
+];
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,61 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+import { courses, blogPosts } from './data/content';
+
+const dynamicRoutes = [
+  ...courses.map((course) => `/courses/${course.slug}`),
+  ...blogPosts.map((post) => `/blog/${post.slug}`)
+];
+
+export default defineNuxtConfig({
+  ssr: true,
+  nitro: {
+    prerender: {
+      routes: [
+        '/',
+        '/about',
+        '/courses',
+        '/blog',
+        '/contact',
+        '/faq',
+        '/terms',
+        '/privacy',
+        ...dynamicRoutes
+      ]
+    }
+  },
+  modules: ['@nuxtjs/tailwindcss'],
+  app: {
+    head: {
+      titleTemplate: '%s - AcadNexus',
+      htmlAttrs: {
+        lang: 'en'
+      },
+      meta: [
+        { charset: 'utf-8' },
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        {
+          name: 'description',
+          content:
+            'AcadNexus is an EdTech platform offering high-impact courses, expert-led pathways, and insights for lifelong learners.'
+        },
+        { name: 'theme-color', content: '#1d4ed8' },
+        { property: 'og:site_name', content: 'AcadNexus' },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:locale', content: 'en_US' }
+      ],
+      link: [
+        { rel: 'icon', type: 'image/svg+xml', href: '/images/favicon.svg' }
+      ]
+    }
+  },
+  tailwindcss: {
+    cssPath: '~/assets/css/tailwind.css',
+    exposeConfig: false,
+    configPath: 'tailwind.config.ts'
+  },
+  runtimeConfig: {
+    public: {
+      siteUrl: 'https://www.acadnexus.com'
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "acadnexus-nuxt-website",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "dependencies": {
+    "@nuxtjs/tailwindcss": "^6.12.1",
+    "@vueuse/core": "^10.9.0",
+    "axios": "^1.6.7",
+    "nuxt": "^3.10.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/typography": "^0.5.10",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1"
+  }
+}

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="bg-white">
+    <NotFound message="We can’t find the page you’re looking for." />
+  </div>
+</template>
+
+<script setup lang="ts">
+import NotFound from '~/components/NotFound.vue';
+
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+useHead({
+  title: 'Page not found',
+  meta: [
+    { name: 'robots', content: 'noindex' },
+    { property: 'og:title', content: 'Page not found' },
+    { property: 'og:url', content: `${siteUrl}/404` }
+  ]
+});
+</script>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="bg-white">
+    <section class="bg-slate-900 py-20 text-white">
+      <div class="mx-auto max-w-4xl px-4 text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-primary/80">About AcadNexus</p>
+        <h1 class="mt-4 text-4xl font-bold sm:text-5xl">Shaping the future of learning and talent</h1>
+        <p class="mt-6 text-base text-slate-200">
+          AcadNexus partners with organizations and professionals to create transformative learning experiences that scale with ambition.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-4 py-20">
+      <div class="grid gap-12 md:grid-cols-2">
+        <div class="space-y-5">
+          <h2 class="text-3xl font-bold text-slate-900">Our Mission</h2>
+          <p class="text-base text-slate-600">
+            We empower learners to navigate change with confidence. AcadNexus delivers adaptive, data-driven learning journeys that blend strategic insights, applied practice, and mentorship from industry leaders.
+          </p>
+          <p class="text-base text-slate-600">
+            From emerging talent to enterprise teams, we equip communities with the skills and mindsets needed to solve the world’s most complex challenges.
+          </p>
+        </div>
+        <div class="space-y-5">
+          <h2 class="text-3xl font-bold text-slate-900">Our Vision</h2>
+          <p class="text-base text-slate-600">
+            We envision a world where equitable access to high-impact learning unlocks innovation everywhere. By combining immersive pedagogy with actionable analytics, AcadNexus ensures every learner thrives.
+          </p>
+          <p class="text-base text-slate-600">
+            We’re committed to sustainability, inclusion, and lifelong curiosity—values that shape every program and partnership we build.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-slate-50 py-20">
+      <div class="mx-auto max-w-6xl px-4">
+        <div class="mx-auto max-w-3xl text-center">
+          <p class="text-sm font-semibold uppercase tracking-wide text-primary">Our Team</p>
+          <h2 class="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">Meet the leaders behind AcadNexus</h2>
+        </div>
+        <div class="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <TestimonialCard
+            v-for="member in team"
+            :key="member.name"
+            :name="member.name"
+            :avatar="member.avatar"
+            :message="member.bio"
+          >
+            <template #role>
+              <p class="text-xs text-slate-500">{{ member.role }}</p>
+            </template>
+          </TestimonialCard>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import TestimonialCard from '~/components/TestimonialCard.vue';
+
+const team = [
+  {
+    name: 'Elena Morris',
+    role: 'Co-founder & Chief Learning Officer',
+    avatar: '/images/testimonials/priya.svg',
+    bio: 'Elena architected blended learning programs for global enterprises and champions inclusive design principles.'
+  },
+  {
+    name: 'Dr. Aisha Patel',
+    role: 'Head of AI Curriculum',
+    avatar: '/images/testimonials/jordan.svg',
+    bio: 'Aisha brings two decades of AI leadership, ensuring every program balances innovation with responsible practice.'
+  },
+  {
+    name: 'Miguel Santos',
+    role: 'Director of Engineering Education',
+    avatar: '/images/testimonials/alex.svg',
+    bio: 'Miguel mentors developers worldwide and designs full-stack pathways that blend technical mastery with collaboration.'
+  }
+];
+
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+useHead({
+  title: 'About AcadNexus',
+  meta: [
+    { name: 'description', content: 'Learn how AcadNexus empowers learners and organizations with mission-driven, data-informed education experiences.' },
+    { property: 'og:title', content: 'About AcadNexus' },
+    { property: 'og:description', content: 'Meet the leaders building equitable, high-impact learning ecosystems.' },
+    { property: 'og:url', content: `${siteUrl}/about` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/about` }]
+});
+</script>

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -1,0 +1,113 @@
+<template>
+  <div v-if="post" class="bg-white">
+    <section class="bg-slate-900 py-16 text-white">
+      <div class="mx-auto max-w-4xl px-4">
+        <Breadcrumbs :path="breadcrumbs" class="text-slate-200" />
+        <p class="mt-2 text-sm uppercase tracking-wide text-primary">{{ post.category }}</p>
+        <h1 class="mt-4 text-4xl font-bold">{{ post.title }}</h1>
+        <p class="mt-4 max-w-2xl text-base text-slate-200">{{ post.excerpt }}</p>
+        <p class="mt-6 text-sm text-slate-300">By {{ post.author }} · {{ formattedDate }}</p>
+      </div>
+    </section>
+
+    <article class="mx-auto max-w-3xl px-4 py-16">
+      <img :src="post.image" :alt="`${post.title} illustration`" class="w-full rounded-3xl object-cover" loading="lazy" />
+      <div class="prose prose-lg prose-slate mt-10 max-w-none">
+        <p v-for="(paragraph, index) in post.content" :key="index">{{ paragraph }}</p>
+      </div>
+      <div class="mt-10 flex flex-wrap items-center gap-4 border-t border-slate-200 pt-6">
+        <span class="text-sm font-semibold uppercase tracking-wide text-slate-500">Share</span>
+        <a
+          v-for="share in shareLinks"
+          :key="share.label"
+          :href="share.href"
+          target="_blank"
+          rel="noopener"
+          class="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-primary hover:text-primary"
+        >
+          <component :is="share.icon" class="h-4 w-4" aria-hidden="true" />
+          {{ share.label }}
+        </a>
+      </div>
+    </article>
+  </div>
+  <NotFound v-else message="Blog post not found" />
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue';
+import Breadcrumbs from '~/components/Breadcrumbs.vue';
+import NotFound from '~/components/NotFound.vue';
+import { blogPosts } from '~/data/content';
+
+const route = useRoute();
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+const post = computed(() => blogPosts.find((post) => post.slug === route.params.slug));
+
+if (!post.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Post not found' });
+}
+
+const breadcrumbs = computed(() => [
+  { label: 'Home', href: '/' },
+  { label: 'Blog', href: '/blog' },
+  { label: post.value?.title ?? 'Article', href: `/blog/${route.params.slug}` }
+]);
+
+const formattedDate = computed(() => new Date(post.value!.date).toLocaleDateString(undefined, {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+}));
+
+const shareLinks = computed(() => {
+  const url = encodeURIComponent(`${siteUrl}/blog/${route.params.slug}`);
+  const text = encodeURIComponent(post.value?.title ?? '');
+  const LinkedInIcon = {
+    render() {
+      return h('svg', { class: 'h-4 w-4', fill: 'currentColor', viewBox: '0 0 24 24' }, [
+        h('path', {
+          d: 'M20.452 20.452h-3.555v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.447-2.136 2.943v5.663H9.354V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.368-1.852 3.601 0 4.267 2.37 4.267 5.455v6.288zM5.337 7.433c-1.144 0-2.069-.926-2.069-2.068 0-1.144.925-2.069 2.069-2.069 1.142 0 2.068.925 2.068 2.069 0 1.142-.926 2.068-2.068 2.068zm1.777 13.019H3.559V9h3.555v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z'
+        })
+      ]);
+    }
+  };
+
+  const TwitterIcon = {
+    render() {
+      return h('svg', { class: 'h-4 w-4', fill: 'currentColor', viewBox: '0 0 24 24' }, [
+        h('path', {
+          d: 'M21.543 7.104c.015.211.015.423.015.636 0 6.507-4.954 14.012-14.012 14.012A13.93 13.93 0 010 19.539a9.86 9.86 0 007.257-2.037 4.93 4.93 0 01-4.597-3.417 4.93 4.93 0 002.22-.085 4.926 4.926 0 01-3.95-4.828v-.062a4.89 4.89 0 002.23.616 4.924 4.924 0 01-1.523-6.573 13.978 13.978 0 0010.15 5.146 5.563 5.563 0 01-.123-1.126 4.926 4.926 0 018.517-3.367 9.72 9.72 0 003.127-1.195 4.92 4.92 0 01-2.165 2.724 9.868 9.868 0 002.828-.77 10.6 10.6 0 01-2.464 2.56z'
+        })
+      ]);
+    }
+  };
+
+  const EmailIcon = {
+    render() {
+      return h('svg', { class: 'h-4 w-4', fill: 'none', stroke: 'currentColor', 'stroke-width': '1.5', viewBox: '0 0 24 24' }, [
+        h('path', { 'stroke-linecap': 'round', 'stroke-linejoin': 'round', d: 'M3 8l9 6 9-6' }),
+        h('rect', { x: '3', y: '6', width: '18', height: '12', rx: '2' })
+      ]);
+    }
+  };
+
+  return [
+    { label: 'LinkedIn', href: `https://www.linkedin.com/sharing/share-offsite/?url=${url}`, icon: LinkedInIcon },
+    { label: 'Twitter', href: `https://twitter.com/intent/tweet?url=${url}&text=${text}`, icon: TwitterIcon },
+    { label: 'Email', href: `mailto:?subject=${text}&body=${url}`, icon: EmailIcon }
+  ];
+});
+
+useHead({
+  title: post.value?.title ?? 'Blog',
+  meta: [
+    { name: 'description', content: post.value?.excerpt ?? '' },
+    { property: 'og:title', content: post.value?.title ?? '' },
+    { property: 'og:description', content: post.value?.excerpt ?? '' },
+    { property: 'og:url', content: `${siteUrl}/blog/${route.params.slug}` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/blog/${route.params.slug}` }]
+});
+</script>

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="bg-white">
+    <section class="bg-slate-900 py-16 text-white">
+      <div class="mx-auto max-w-6xl px-4">
+        <Breadcrumbs :path="breadcrumbs" class="text-slate-200" />
+        <h1 class="mt-4 text-4xl font-bold">Insights & Resources</h1>
+        <p class="mt-4 max-w-2xl text-base text-slate-200">
+          Explore analysis, best practices, and stories from the AcadNexus community to inform your learning strategy.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-4 py-16">
+      <form class="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-sm md:flex-row md:items-center md:justify-between" @submit.prevent>
+        <div>
+          <label for="category" class="block text-xs font-semibold uppercase tracking-wide text-slate-500">Category</label>
+          <select
+            id="category"
+            v-model="selectedCategory"
+            class="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          >
+            <option value="">All</option>
+            <option v-for="category in categories" :key="category" :value="category">{{ category }}</option>
+          </select>
+        </div>
+        <button
+          type="button"
+          class="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-primary hover:text-primary"
+          @click="selectedCategory = ''"
+        >
+          Clear Filter
+        </button>
+      </form>
+
+      <div class="mt-12 grid gap-6 md:grid-cols-2">
+        <BlogCard v-for="post in filteredPosts" :key="post.slug" v-bind="post" />
+      </div>
+      <p v-if="!filteredPosts.length" class="mt-12 text-center text-sm text-slate-500">No articles match this category yet.</p>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Breadcrumbs from '~/components/Breadcrumbs.vue';
+import BlogCard from '~/components/BlogCard.vue';
+import { blogPosts } from '~/data/content';
+
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+const breadcrumbs = [
+  { label: 'Home', href: '/' },
+  { label: 'Blog', href: '/blog' }
+];
+
+const categories = [...new Set(blogPosts.map((post) => post.category))];
+const selectedCategory = ref('');
+
+const filteredPosts = computed(() => {
+  if (!selectedCategory.value) return blogPosts;
+  return blogPosts.filter((post) => post.category === selectedCategory.value);
+});
+
+useHead({
+  title: 'Blog',
+  meta: [
+    { name: 'description', content: 'Stay ahead with AcadNexus thought leadership on AI, learning design, and the future of work.' },
+    { property: 'og:title', content: 'AcadNexus Blog' },
+    { property: 'og:description', content: 'Articles, guides, and perspectives from AcadNexus experts and alumni.' },
+    { property: 'og:url', content: `${siteUrl}/blog` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/blog` }]
+});
+</script>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="bg-white">
+    <section class="bg-slate-900 py-16 text-white">
+      <div class="mx-auto max-w-4xl px-4 text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-primary/80">Contact</p>
+        <h1 class="mt-4 text-4xl font-bold sm:text-5xl">Let’s build the future of learning together</h1>
+        <p class="mt-4 text-base text-slate-200">
+          Share your goals and we’ll tailor a learning plan for your team or professional journey.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-4 py-16">
+      <div class="grid gap-12 lg:grid-cols-[1.2fr,1fr]">
+        <div>
+          <h2 id="contact-heading" class="text-2xl font-semibold text-slate-900">Send us a message</h2>
+          <p class="mt-3 text-sm text-slate-600">
+            Our team responds within two business days. Required fields are marked with an asterisk (*).
+          </p>
+          <ContactForm :submit-action="submitForm" button-label="Send message" class="mt-8" />
+        </div>
+        <aside class="space-y-6 rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-sm">
+          <div>
+            <h3 class="text-lg font-semibold text-slate-900">Ways to connect</h3>
+            <ul class="mt-4 space-y-2 text-sm text-slate-600">
+              <li>Email: <a href="mailto:hello@acadnexus.com" class="text-primary hover:underline">hello@acadnexus.com</a></li>
+              <li>Phone: <a href="tel:+1234567890" class="text-primary hover:underline">+1 (234) 567-890</a></li>
+              <li>Address: 123 Innovation Drive, Boston, MA</li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-slate-900">Visit us</h3>
+            <div class="mt-4 overflow-hidden rounded-2xl shadow">
+              <iframe
+                title="AcadNexus office location"
+                src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2948.5766038779077!2d-71.05829182373237!3d42.360082871195436!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89e370aaf18b90c1%3A0x9b5fdf4b62e1d2f!2sBoston%20City%20Hall!5e0!3m2!1sen!2sus!4v1700000000000!5m2!1sen!2sus"
+                width="100%"
+                height="260"
+                style="border:0"
+                allowfullscreen=""
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade"
+              ></iframe>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ContactForm from '~/components/ContactForm.vue';
+
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+const submitForm = async (payload: { name: string; email: string; message: string }) => {
+  const { $axios } = useNuxtApp();
+  try {
+    await $axios.post('/contact', payload);
+  } catch (error) {
+    // Fallback silently; ContactForm handles error state.
+    throw error;
+  }
+};
+
+useHead({
+  title: 'Contact',
+  meta: [
+    { name: 'description', content: 'Reach out to the AcadNexus team for partnership inquiries, custom programs, or learner support.' },
+    { property: 'og:title', content: 'Contact AcadNexus' },
+    { property: 'og:description', content: 'Let’s collaborate on immersive learning experiences tailored to your goals.' },
+    { property: 'og:url', content: `${siteUrl}/contact` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/contact` }]
+});
+</script>

--- a/pages/courses/[slug].vue
+++ b/pages/courses/[slug].vue
@@ -1,0 +1,106 @@
+<template>
+  <div v-if="course" class="bg-white">
+    <section class="bg-slate-900 py-16 text-white">
+      <div class="mx-auto max-w-5xl px-4">
+        <Breadcrumbs :path="breadcrumbs" class="text-slate-200" />
+        <h1 class="mt-4 text-4xl font-bold">{{ course.title }}</h1>
+        <p class="mt-4 max-w-3xl text-base text-slate-200">{{ course.description }}</p>
+        <div class="mt-6 flex flex-wrap gap-4 text-sm">
+          <span class="rounded-full bg-white/10 px-4 py-1">Category: {{ course.category }}</span>
+          <span class="rounded-full bg-white/10 px-4 py-1">Level: {{ course.level }}</span>
+          <span class="rounded-full bg-white/10 px-4 py-1">Duration: {{ course.duration }}</span>
+        </div>
+        <NuxtLink
+          to="/contact"
+          class="mt-8 inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-primary transition hover:-translate-y-1 hover:bg-slate-100"
+        >
+          Enroll Now
+          <span aria-hidden="true">→</span>
+        </NuxtLink>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-5xl px-4 py-16">
+      <div class="grid gap-12 md:grid-cols-[2fr,1fr]">
+        <div class="space-y-8">
+          <div>
+            <h2 class="text-2xl font-semibold text-slate-900">What you'll learn</h2>
+            <ul class="mt-4 space-y-3 text-sm text-slate-600">
+              <li v-for="topic in course.syllabus" :key="topic" class="flex items-start gap-3">
+                <span class="mt-1 inline-flex h-2 w-2 rounded-full bg-primary"></span>
+                <span>{{ topic }}</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <aside class="space-y-6 rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-sm">
+          <div>
+            <h3 class="text-lg font-semibold text-slate-900">Course Snapshot</h3>
+            <ul class="mt-4 space-y-3 text-sm text-slate-600">
+              <li><strong>Format:</strong> Live workshops + async labs</li>
+              <li><strong>Effort:</strong> 4-6 hrs per week</li>
+              <li><strong>Tools:</strong> Collaborative workspaces, analytics dashboards</li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold text-slate-900">Instructor</h3>
+            <div class="mt-4 flex items-start gap-4">
+              <img :src="course.instructorImage" :alt="`${course.instructor.name} portrait`" class="h-16 w-16 rounded-full object-cover" loading="lazy" />
+              <div>
+                <p class="text-base font-semibold text-slate-900">{{ course.instructor.name }}</p>
+                <p class="text-xs text-slate-500">{{ course.instructor.role }}</p>
+                <p class="mt-3 text-sm text-slate-600">{{ course.instructor.bio }}</p>
+              </div>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </section>
+  </div>
+  <NotFound v-else message="Course not found" />
+</template>
+
+<script setup lang="ts">
+import Breadcrumbs from '~/components/Breadcrumbs.vue';
+import NotFound from '~/components/NotFound.vue';
+import { courses } from '~/data/content';
+
+const route = useRoute();
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+const instructorAvatars: Record<string, string> = {
+  'Dr. Aisha Patel': '/images/testimonials/jordan.svg',
+  'Miguel Santos': '/images/testimonials/alex.svg',
+  'Sophia Chen': '/images/testimonials/priya.svg'
+};
+
+const course = computed(() => {
+  return courses
+    .map((course) => ({
+      ...course,
+      instructorImage: instructorAvatars[course.instructor.name] ?? '/images/testimonials/jordan.svg'
+    }))
+    .find((course) => course.slug === route.params.slug);
+});
+
+if (!course.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Course not found' });
+}
+
+const breadcrumbs = computed(() => [
+  { label: 'Home', href: '/' },
+  { label: 'Courses', href: '/courses' },
+  { label: course.value?.title ?? 'Course', href: `/courses/${route.params.slug}` }
+]);
+
+useHead({
+  title: course.value?.title ?? 'Course',
+  meta: [
+    { name: 'description', content: course.value?.description ?? '' },
+    { property: 'og:title', content: course.value?.title ?? '' },
+    { property: 'og:description', content: course.value?.description ?? '' },
+    { property: 'og:url', content: `${siteUrl}/courses/${route.params.slug}` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/courses/${route.params.slug}` }]
+});
+</script>

--- a/pages/courses/index.vue
+++ b/pages/courses/index.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="bg-white">
+    <section class="bg-slate-900 py-16 text-white">
+      <div class="mx-auto flex max-w-6xl flex-col gap-6 px-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <Breadcrumbs :path="breadcrumbs" class="text-slate-200" />
+          <h1 class="mt-4 text-4xl font-bold">Courses</h1>
+          <p class="mt-3 max-w-2xl text-base text-slate-200">
+            Explore immersive programs designed to build critical skills through guided practice, coaching, and community.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-4 py-16">
+      <form class="grid gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-6 shadow-sm md:grid-cols-4" @submit.prevent>
+        <div>
+          <label for="category" class="block text-xs font-semibold uppercase tracking-wide text-slate-500">Category</label>
+          <select
+            id="category"
+            v-model="filters.category"
+            class="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          >
+            <option value="">All</option>
+            <option v-for="category in categories" :key="category" :value="category">{{ category }}</option>
+          </select>
+        </div>
+        <div>
+          <label for="level" class="block text-xs font-semibold uppercase tracking-wide text-slate-500">Level</label>
+          <select
+            id="level"
+            v-model="filters.level"
+            class="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          >
+            <option value="">All</option>
+            <option v-for="level in levels" :key="level" :value="level">{{ level }}</option>
+          </select>
+        </div>
+        <div>
+          <label for="duration" class="block text-xs font-semibold uppercase tracking-wide text-slate-500">Duration</label>
+          <select
+            id="duration"
+            v-model="filters.duration"
+            class="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          >
+            <option value="">All</option>
+            <option v-for="duration in durations" :key="duration" :value="duration">{{ duration }}</option>
+          </select>
+        </div>
+        <div class="flex items-end justify-end">
+          <button
+            type="button"
+            class="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-primary hover:text-primary"
+            @click="resetFilters"
+          >
+            Reset
+          </button>
+        </div>
+      </form>
+
+      <div class="mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        <CourseCard
+          v-for="course in filteredCourses"
+          :key="course.slug"
+          :title="course.title"
+          :description="course.description"
+          :image="course.image"
+          :category="course.category"
+          :duration="course.duration"
+          :cta="`/courses/${course.slug}`"
+        />
+      </div>
+      <p v-if="!filteredCourses.length" class="mt-12 text-center text-sm text-slate-500">
+        No courses match your criteria. Try adjusting the filters.
+      </p>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Breadcrumbs from '~/components/Breadcrumbs.vue';
+import CourseCard from '~/components/CourseCard.vue';
+import { courses } from '~/data/content';
+
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+const breadcrumbs = [
+  { label: 'Home', href: '/' },
+  { label: 'Courses', href: '/courses' }
+];
+
+const filters = reactive({
+  category: '',
+  level: '',
+  duration: ''
+});
+
+const categories = [...new Set(courses.map((course) => course.category))];
+const levels = [...new Set(courses.map((course) => course.level))];
+const durations = [...new Set(courses.map((course) => course.duration))];
+
+const filteredCourses = computed(() => {
+  return courses.filter((course) => {
+    const matchesCategory = filters.category ? course.category === filters.category : true;
+    const matchesLevel = filters.level ? course.level === filters.level : true;
+    const matchesDuration = filters.duration ? course.duration === filters.duration : true;
+    return matchesCategory && matchesLevel && matchesDuration;
+  });
+});
+
+const resetFilters = () => {
+  filters.category = '';
+  filters.level = '';
+  filters.duration = '';
+};
+
+useHead({
+  title: 'Courses',
+  meta: [
+    { name: 'description', content: 'Browse AcadNexus courses across AI, web development, data storytelling, and more.' },
+    { property: 'og:title', content: 'AcadNexus Courses' },
+    { property: 'og:description', content: 'Filter immersive programs by category, level, and duration to find your next learning sprint.' },
+    { property: 'og:url', content: `${siteUrl}/courses` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/courses` }]
+});
+</script>

--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="bg-white">
+    <section class="bg-slate-900 py-16 text-white">
+      <div class="mx-auto max-w-4xl px-4 text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-primary/80">FAQ</p>
+        <h1 class="mt-4 text-4xl font-bold sm:text-5xl">Answers to common questions</h1>
+        <p class="mt-4 text-base text-slate-200">
+          Find clarity on programs, enrollment, and support. Need more help? Our team is one message away.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-4xl px-4 py-16">
+      <div class="space-y-4">
+        <FAQItem v-for="item in faqs" :key="item.question" v-bind="item" />
+      </div>
+      <div class="mt-12 rounded-2xl bg-slate-900 px-6 py-8 text-white">
+        <h2 class="text-2xl font-semibold">Still curious?</h2>
+        <p class="mt-3 text-sm text-slate-200">
+          Reach out to our learner success team and we’ll respond within two business days.
+        </p>
+        <NuxtLink
+          to="/contact"
+          class="mt-6 inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-primary transition hover:-translate-y-1 hover:bg-slate-100"
+        >
+          Contact us
+          <span aria-hidden="true">→</span>
+        </NuxtLink>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import FAQItem from '~/components/FAQItem.vue';
+import { faqs } from '~/data/content';
+
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+useHead({
+  title: 'FAQ',
+  meta: [
+    { name: 'description', content: 'Discover answers to frequently asked questions about AcadNexus programs, cohorts, and support.' },
+    { property: 'og:title', content: 'AcadNexus FAQ' },
+    { property: 'og:description', content: 'Get clarity on learning formats, corporate packages, and learner support services.' },
+    { property: 'og:url', content: `${siteUrl}/faq` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/faq` }]
+});
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,175 @@
+<template>
+  <div>
+    <HeroSection
+      title="Reimagine Learning with AcadNexus"
+      subtitle="Accelerate your career with industry-aligned programs, world-class mentors, and an active community of innovators."
+      cta-text="Join the Community"
+      cta-link="/contact"
+    />
+
+    <section class="mx-auto max-w-7xl px-4 py-20">
+      <div class="mx-auto max-w-3xl text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-primary">Why AcadNexus</p>
+        <h2 class="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">Learning designed for impact</h2>
+        <p class="mt-4 text-base text-slate-600">
+          Our platform blends human expertise with smart technology to unlock meaningful outcomes for learners and organizations.
+        </p>
+      </div>
+      <div class="mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <FeatureCard v-for="feature in features" :key="feature.title" v-bind="feature" />
+      </div>
+    </section>
+
+    <section class="bg-white py-20">
+      <div class="mx-auto max-w-7xl px-4">
+        <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p class="text-sm font-semibold uppercase tracking-wide text-primary">Latest Courses</p>
+            <h2 class="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">Build job-ready skills faster</h2>
+            <p class="mt-4 max-w-2xl text-base text-slate-600">
+              Curated programs with guided pathways, real-world projects, and support designed to help you apply new skills immediately.
+            </p>
+          </div>
+          <NuxtLink
+            to="/courses"
+            class="inline-flex items-center gap-2 rounded-full border border-primary px-5 py-2 text-sm font-semibold text-primary transition hover:bg-primary/10"
+          >
+            View all courses
+            <span aria-hidden="true">→</span>
+          </NuxtLink>
+        </div>
+        <div class="mt-12 grid gap-6 md:grid-cols-3">
+          <CourseCard
+            v-for="course in courses.slice(0, 3)"
+            :key="course.slug"
+            :title="course.title"
+            :description="course.description"
+            :image="course.image"
+            :category="course.category"
+            :duration="course.duration"
+            :cta="`/courses/${course.slug}`"
+          />
+        </div>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-7xl px-4 py-20">
+      <div class="mx-auto max-w-3xl text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-primary">Learner Stories</p>
+        <h2 class="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">Trusted by teams and professionals worldwide</h2>
+      </div>
+      <div class="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <TestimonialCard
+          v-for="testimonial in testimonials"
+          :key="testimonial.name"
+          :name="testimonial.name"
+          :avatar="testimonial.avatar"
+          :message="testimonial.message"
+        >
+          <template #role>
+            <p class="text-xs text-slate-500">{{ testimonial.role }}</p>
+          </template>
+        </TestimonialCard>
+      </div>
+    </section>
+
+    <section class="bg-white py-20">
+      <div class="mx-auto max-w-7xl px-4">
+        <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p class="text-sm font-semibold uppercase tracking-wide text-primary">From the Blog</p>
+            <h2 class="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">Insights to power your learning strategy</h2>
+          </div>
+          <NuxtLink
+            to="/blog"
+            class="inline-flex items-center gap-2 rounded-full border border-primary px-5 py-2 text-sm font-semibold text-primary transition hover:bg-primary/10"
+          >
+            Explore all posts
+            <span aria-hidden="true">→</span>
+          </NuxtLink>
+        </div>
+        <div class="mt-12 grid gap-6 md:grid-cols-2">
+          <BlogCard v-for="post in blogPosts.slice(0, 2)" :key="post.slug" v-bind="post" />
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue';
+import HeroSection from '~/components/HeroSection.vue';
+import FeatureCard from '~/components/FeatureCard.vue';
+import CourseCard from '~/components/CourseCard.vue';
+import TestimonialCard from '~/components/TestimonialCard.vue';
+import BlogCard from '~/components/BlogCard.vue';
+import { courses, blogPosts, testimonials } from '~/data/content';
+
+const LightningIcon = {
+  render() {
+    return h('svg', { class: 'h-6 w-6', fill: 'currentColor', viewBox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg' }, [
+      h('path', { d: 'M13 2L3 14h7l-1 8 10-12h-7l1-8z', 'fill-rule': 'evenodd', 'clip-rule': 'evenodd' })
+    ]);
+  }
+};
+
+const CompassIcon = {
+  render() {
+    return h('svg', { class: 'h-6 w-6', fill: 'none', stroke: 'currentColor', 'stroke-width': '1.5', viewBox: '0 0 24 24' }, [
+      h('path', { 'stroke-linecap': 'round', 'stroke-linejoin': 'round', d: 'M10.5 6.75L6.75 17.25l10.5-3.75L13.5 6.75l-3 4.5z' }),
+      h('circle', { cx: '12', cy: '12', r: '9' })
+    ]);
+  }
+};
+
+const ShieldIcon = {
+  render() {
+    return h('svg', { class: 'h-6 w-6', fill: 'none', stroke: 'currentColor', 'stroke-width': '1.5', viewBox: '0 0 24 24' }, [
+      h('path', { 'stroke-linecap': 'round', 'stroke-linejoin': 'round', d: 'M12 3l7.5 4.5v4.5c0 5-3.5 9.5-7.5 9.5S4.5 17 4.5 12V7.5L12 3z' })
+    ]);
+  }
+};
+
+const SparkleIcon = {
+  render() {
+    return h('svg', { class: 'h-6 w-6', fill: 'currentColor', viewBox: '0 0 24 24' }, [
+      h('path', { d: 'M12 2l1.8 4.6L18 8.4l-4.2 1.8L12 15l-1.8-4.8L6 8.4l4.2-1.8L12 2zM5 18l.9-2.1L8 15l-2.1-.9L5 12l-.9 2.1L2 15l2.1.9L5 18zm12 0l.9-2.1L20 15l-2.1-.9L17 12l-.9 2.1L14 15l2.1.9L17 18z' })
+    ]);
+  }
+};
+
+const features = [
+  {
+    icon: LightningIcon,
+    title: 'Immersive Learning Sprints',
+    description: 'Accelerated cohorts combine live workshops, labs, and peer review to help you apply knowledge immediately.'
+  },
+  {
+    icon: CompassIcon,
+    title: 'Personalized Pathways',
+    description: 'Adaptive pathways and mentor check-ins keep your learning aligned with goals and performance metrics.'
+  },
+  {
+    icon: ShieldIcon,
+    title: 'Enterprise-Grade Governance',
+    description: 'Security, compliance, and analytics dashboards ensure leaders can scale learning responsibly.'
+  },
+  {
+    icon: SparkleIcon,
+    title: 'Community That Inspires',
+    description: 'Join a global network of professionals sharing insights, resources, and opportunities every day.'
+  }
+];
+
+useHead({
+  title: 'AcadNexus | Learning reimagined',
+  meta: [
+    { name: 'description', content: 'Discover AcadNexus: immersive EdTech programs, strategic upskilling, and resources for the future of work.' },
+    { property: 'og:title', content: 'AcadNexus — Learning reimagined' },
+    { property: 'og:description', content: 'Explore experiential courses, expert mentors, and insights powering tomorrow\'s teams.' },
+    { property: 'og:url', content: `${useRuntimeConfig().public.siteUrl}` },
+    { name: 'twitter:card', content: 'summary_large_image' }
+  ],
+  link: [{ rel: 'canonical', href: `${useRuntimeConfig().public.siteUrl}` }]
+});
+</script>

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="bg-white">
+    <section class="bg-slate-900 py-16 text-white">
+      <div class="mx-auto max-w-4xl px-4 text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-primary/80">Privacy Policy</p>
+        <h1 class="mt-4 text-4xl font-bold sm:text-5xl">How we protect your data</h1>
+        <p class="mt-4 text-base text-slate-200">
+          We are committed to safeguarding personal information and maintaining transparent data practices.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-4xl px-4 py-16">
+      <StaticContent>
+        <h2>1. Information We Collect</h2>
+        <p>
+          AcadNexus collects account details, learning activity, and engagement analytics to personalize your experience and improve our services.
+        </p>
+        <h2>2. How We Use Information</h2>
+        <p>
+          Data helps us deliver courses, communicate updates, and provide support. We may aggregate anonymized insights for research and product development.
+        </p>
+        <h2>3. Data Sharing</h2>
+        <p>
+          We do not sell personal data. Limited sharing occurs with trusted service providers who support learning delivery under strict confidentiality.
+        </p>
+        <h2>4. Security</h2>
+        <p>
+          We implement technical and organizational safeguards, including encryption, access controls, and monitoring, to protect data integrity.
+        </p>
+        <h2>5. Your Rights</h2>
+        <p>
+          You may request access, correction, or deletion of personal data at any time by contacting privacy@acadnexus.com.
+        </p>
+      </StaticContent>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import StaticContent from '~/components/StaticContent.vue';
+
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+useHead({
+  title: 'Privacy Policy',
+  meta: [
+    { name: 'description', content: 'Understand AcadNexus privacy practices, data usage, and how to exercise your rights.' },
+    { property: 'og:title', content: 'AcadNexus Privacy Policy' },
+    { property: 'og:description', content: 'Learn about our commitment to safeguarding learner and partner information.' },
+    { property: 'og:url', content: `${siteUrl}/privacy` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/privacy` }]
+});
+</script>

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="bg-white">
+    <section class="bg-slate-900 py-16 text-white">
+      <div class="mx-auto max-w-4xl px-4 text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-primary/80">Terms of Service</p>
+        <h1 class="mt-4 text-4xl font-bold sm:text-5xl">AcadNexus Terms</h1>
+        <p class="mt-4 text-base text-slate-200">
+          Review the terms governing your use of AcadNexus services, courses, and community platforms.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-4xl px-4 py-16">
+      <StaticContent>
+        <h2>1. Acceptance of Terms</h2>
+        <p>
+          By accessing AcadNexus, you agree to these Terms of Service and any additional guidelines presented during enrollment or platform use.
+        </p>
+        <h2>2. Use of Services</h2>
+        <p>
+          AcadNexus content is provided for personal or organizational learning. Redistribution, resale, or unauthorized recording of sessions is prohibited.
+        </p>
+        <h2>3. Payment & Refunds</h2>
+        <p>
+          Payments are due upon registration. Refunds may be issued according to the cancellation policy specified for each program.
+        </p>
+        <h2>4. Intellectual Property</h2>
+        <p>
+          All content, branding, and materials are owned by AcadNexus or our partners. You receive a limited license for your learning experience.
+        </p>
+        <h2>5. Conduct</h2>
+        <p>
+          We foster inclusive, respectful communities. AcadNexus reserves the right to remove access for behavior that violates our Code of Conduct.
+        </p>
+      </StaticContent>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import StaticContent from '~/components/StaticContent.vue';
+
+const siteUrl = useRuntimeConfig().public.siteUrl;
+
+useHead({
+  title: 'Terms of Service',
+  meta: [
+    { name: 'description', content: 'Read the legal terms and acceptable use guidelines for AcadNexus courses and services.' },
+    { property: 'og:title', content: 'AcadNexus Terms of Service' },
+    { property: 'og:description', content: 'Understand the agreements that govern participation in AcadNexus learning experiences.' },
+    { property: 'og:url', content: `${siteUrl}/terms` }
+  ],
+  link: [{ rel: 'canonical', href: `${siteUrl}/terms` }]
+});
+</script>

--- a/plugins/axios.ts
+++ b/plugins/axios.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+export default defineNuxtPlugin(() => {
+  const api = axios.create({
+    baseURL: '/api',
+    timeout: 5000
+  });
+
+  return {
+    provide: {
+      axios: api
+    }
+  };
+});

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/images/blog/ai-blog.svg
+++ b/public/images/blog/ai-blog.svg
@@ -1,0 +1,7 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='420' viewBox='0 0 800 420'>
+  <rect width='800' height='420' fill='#0f172a'/>
+  <circle cx='200' cy='210' r='120' fill='#1d4ed8' fill-opacity='0.6'/>
+  <circle cx='420' cy='180' r='80' fill='#38bdf8' fill-opacity='0.8'/>
+  <circle cx='600' cy='240' r='100' fill='#22d3ee' fill-opacity='0.75'/>
+  <text x='50%' y='80%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='48' fill='white'>AI in 2025</text>
+</svg>

--- a/public/images/blog/future-skills.svg
+++ b/public/images/blog/future-skills.svg
@@ -1,0 +1,10 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='420' viewBox='0 0 800 420'>
+  <rect width='800' height='420' fill='#6366f1'/>
+  <g fill='#eef2ff'>
+    <rect x='160' y='120' width='80' height='200' rx='16'/>
+    <rect x='280' y='80' width='80' height='240' rx='16'/>
+    <rect x='400' y='160' width='80' height='160' rx='16'/>
+    <rect x='520' y='60' width='80' height='260' rx='16'/>
+  </g>
+  <text x='50%' y='82%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='44' fill='#312e81'>Future Skills</text>
+</svg>

--- a/public/images/blog/learning-experiences.svg
+++ b/public/images/blog/learning-experiences.svg
@@ -1,0 +1,10 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='420' viewBox='0 0 800 420'>
+  <rect width='800' height='420' fill='#f59e0b'/>
+  <g fill='#fff3c4'>
+    <circle cx='180' cy='140' r='70'/>
+    <circle cx='320' cy='240' r='90'/>
+    <circle cx='520' cy='180' r='60'/>
+    <circle cx='650' cy='260' r='80'/>
+  </g>
+  <text x='50%' y='80%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='44' fill='#78350f'>Learning Experiences</text>
+</svg>

--- a/public/images/courses/ai-course.svg
+++ b/public/images/courses/ai-course.svg
@@ -1,0 +1,10 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='500' viewBox='0 0 800 500'>
+  <defs>
+    <linearGradient id='grad-ai' x1='0%' y1='0%' x2='100%' y2='100%'>
+      <stop offset='0%' stop-color='#1d4ed8'/>
+      <stop offset='100%' stop-color='#1e3a8a'/>
+    </linearGradient>
+  </defs>
+  <rect width='800' height='500' fill='url(#grad-ai)'/>
+  <text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='48' fill='white'>AI Fundamentals</text>
+</svg>

--- a/public/images/courses/data-course.svg
+++ b/public/images/courses/data-course.svg
@@ -1,0 +1,10 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='500' viewBox='0 0 800 500'>
+  <rect width='800' height='500' fill='#14b8a6'/>
+  <g transform='translate(120 120)'>
+    <rect x='40' y='140' width='80' height='140' rx='12' fill='#0f172a' fill-opacity='0.2'/>
+    <rect x='160' y='80' width='80' height='200' rx='12' fill='#0f172a' fill-opacity='0.35'/>
+    <rect x='280' y='40' width='80' height='240' rx='12' fill='#0f172a' fill-opacity='0.5'/>
+    <rect x='400' y='0' width='80' height='280' rx='12' fill='#0f172a' fill-opacity='0.65'/>
+  </g>
+  <text x='50%' y='85%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='44' fill='white'>Data Storytelling</text>
+</svg>

--- a/public/images/courses/web-course.svg
+++ b/public/images/courses/web-course.svg
@@ -1,0 +1,9 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='500' viewBox='0 0 800 500'>
+  <rect width='800' height='500' fill='#0ea5e9'/>
+  <rect x='120' y='120' width='560' height='280' rx='24' fill='#f8fafc'/>
+  <rect x='160' y='160' width='200' height='40' rx='12' fill='#1d4ed8' fill-opacity='0.9'/>
+  <rect x='160' y='220' width='480' height='24' rx='12' fill='#1e293b' fill-opacity='0.4'/>
+  <rect x='160' y='260' width='360' height='24' rx='12' fill='#1e293b' fill-opacity='0.3'/>
+  <rect x='160' y='300' width='420' height='24' rx='12' fill='#1e293b' fill-opacity='0.2'/>
+  <text x='50%' y='60%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='44' fill='#0f172a'>Full-Stack Web</text>
+</svg>

--- a/public/images/favicon.svg
+++ b/public/images/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'>
+  <rect width='64' height='64' rx='12' fill='#1d4ed8'/>
+  <path d='M18 20h12c6.627 0 12 5.373 12 12S36.627 44 30 44H18V20zm12 18c3.314 0 6-2.686 6-6s-2.686-6-6-6h-6v12h6z' fill='white'/>
+</svg>

--- a/public/images/hero-illustration.svg
+++ b/public/images/hero-illustration.svg
@@ -1,0 +1,9 @@
+<svg width="720" height="480" viewBox="0 0 720 480" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="480" rx="32" fill="#E2E8F0"/>
+  <circle cx="180" cy="180" r="80" fill="#1D4ED8" fill-opacity="0.8"/>
+  <circle cx="360" cy="240" r="120" fill="#1E3A8A" fill-opacity="0.75"/>
+  <circle cx="540" cy="180" r="80" fill="#F59E0B" fill-opacity="0.8"/>
+  <rect x="160" y="300" width="400" height="80" rx="16" fill="#fff"/>
+  <rect x="190" y="320" width="160" height="16" rx="8" fill="#CBD5F5"/>
+  <rect x="190" y="350" width="240" height="16" rx="8" fill="#A5B4FC"/>
+</svg>

--- a/public/images/logo-light.svg
+++ b/public/images/logo-light.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="32" viewBox="0 0 120 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="32" rx="8" fill="white" fill-opacity="0.1" stroke="white" stroke-opacity="0.4"/>
+  <text x="16" y="21" fill="white" font-family="Inter, Arial, sans-serif" font-weight="600" font-size="16">AcadNexus</text>
+</svg>

--- a/public/images/logo.svg
+++ b/public/images/logo.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="32" viewBox="0 0 120 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="32" rx="8" fill="#1D4ED8"/>
+  <text x="16" y="21" fill="white" font-family="Inter, Arial, sans-serif" font-weight="600" font-size="16">AcadNexus</text>
+</svg>

--- a/public/images/testimonials/alex.svg
+++ b/public/images/testimonials/alex.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'>
+  <rect width='200' height='200' rx='32' fill='#14b8a6'/>
+  <text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='64' fill='white'>A</text>
+</svg>

--- a/public/images/testimonials/jordan.svg
+++ b/public/images/testimonials/jordan.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'>
+  <rect width='200' height='200' rx='32' fill='#1d4ed8'/>
+  <text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='64' fill='white'>J</text>
+</svg>

--- a/public/images/testimonials/priya.svg
+++ b/public/images/testimonials/priya.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'>
+  <rect width='200' height='200' rx='32' fill='#f59e0b'/>
+  <text x='50%' y='55%' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial' font-size='64' fill='white'>P</text>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,27 @@
+import type { Config } from 'tailwindcss';
+import typography from '@tailwindcss/typography';
+
+export default <Partial<Config>>{
+  content: [
+    './components/**/*.{vue,js,ts}',
+    './layouts/**/*.vue',
+    './pages/**/*.vue',
+    './plugins/**/*.{js,ts}',
+    './app.vue'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#1d4ed8',
+          dark: '#1e3a8a'
+        },
+        secondary: '#f59e0b'
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui']
+      }
+    }
+  },
+  plugins: [typography]
+};


### PR DESCRIPTION
## Summary
- set up a Nuxt 3 static marketing site with TailwindCSS integration, SEO defaults, and static prerendering routes
- build reusable components with mock data powering hero, course, testimonial, blog, and contact experiences
- add complete page set including dynamic course and blog details, FAQ, legal content, and branded SVG assets

## Testing
- npm install *(fails: registry returned 403 for @nuxtjs/tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c28d6ef08322a183e3242fc73d7d